### PR TITLE
Evaluate type property to test for simpl-schema object structue

### DIFF
--- a/schema-graphql-bridge.js
+++ b/schema-graphql-bridge.js
@@ -103,14 +103,18 @@ const getFieldSchema = (schema, k, name, custom = {}) => {
   let key = k.substr(k.lastIndexOf('.')+1),
     value = null;
 
+  const typeDef = S[k].type.constructor.name === 'SimpleSchemaGroup'
+    ? S[k].type.definitions[0].type
+    : S[k].type;
+
   if(custom[k])
     value = custom[k];
-  else if(S[k].type == Object) {
+  else if(typeDef == Object) {
     // Only add it if it has keys
     if(schema._objectKeys[k+'.'] && schema._objectKeys[k+'.'].length)
       value = `${typeName(k, name)}`;
   }
-  else if(S[k].type == Array && S[`${k}.$`]) {
+  else if(typeDef == Array && S[`${k}.$`]) {
     if(gqlType[S[`${k}.$`].type])
       value = `[${gqlType[S[`${k}.$`].type]}]`;
     // Maybe it is an Object
@@ -118,7 +122,7 @@ const getFieldSchema = (schema, k, name, custom = {}) => {
       value = `[${typeName(k, name)}]`;
   }
   else
-    value = `${gqlType[S[k].type]}`;
+    value = `${gqlType[typeDef]}`;
 
   if(!value)
     return ``;


### PR DESCRIPTION
Along with the launch of simple-schema 2, and the migration to using the simpl-schema npm package, a breaking change was introduced which prevented this package from inferring field
types correctly. The change made within simple-schema supports the ability to set [multiple types for a single field](
https://github.com/aldeed/node-simple-schema#multiple-definitions-for-one-key).

The problem I encountered upon attempting to use simpl-schema was that the type for every field was `undefined`, because of the new underlying object structure, a ternary was added to correctly access the needed property... this way both 2.x+ and legacy simple-schema should be usable. 

This diff doesn't fully support this feature but it prevents it from breaking the schema when simple-schema is used in the familiar one-def-per-field pattern I'm used to. In essence, any additional types are ignored and only the first is used to produce the schema. 