### PR TITLE
Map RegExp type defs to String when building schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,5 +158,6 @@ Options:
 Should work with all types.
 
 - `Date` is transformed into `String`
+- [Regular expressions](https://github.com/aldeed/node-simple-schema#regex) are transformed into `String`
 - `Object`s are transformed into GraphQL object types, with a camel cased name, based on it's SimpleSchema path.
 

--- a/schema-graphql-bridge.js
+++ b/schema-graphql-bridge.js
@@ -117,6 +117,8 @@ const getFieldSchema = (schema, k, name, custom = {}) => {
     else if(!value && schema._objectKeys[k+'.$.'])
       value = `[${typeName(k, name)}]`;
   }
+  else if(typeDef instanceof RegExp)
+    value = `${gqlType[String]}`;
   else
     value = `${gqlType[S[k].type]}`;
 
@@ -191,6 +193,7 @@ gqlType[String] = 'String';
 gqlType[Number] = 'Float';
 gqlType[Boolean] = 'Boolean';
 gqlType[Date] = 'String';
+gqlType[RegExp] = 'String';
 
 defaultMocks = {
   String: () => 'It works!',


### PR DESCRIPTION
It's not uncommon to use a regex pattern as a type when building a schema via simple-schema. This practice is supported in the docs [as seen here](https://github.com/aldeed/node-simple-schema#regex)

This diff maps these types to Strings for the purposes of generating the schema. This way the developer can still enjoy the validation control of using regex with seamless graphql-bridge support!

Adding `RegExp` to the `gqlType` on line 196 doesn't really do anything unless a schema was created as shown below (which probably isn't too likely)

```js
  name: {
    type: RexExp
  }
```

That said, the accounts for the much more likely situation of...

```js
  clientId: {
    type: SimpleSchema.RegEx.Id
  }
```

Once again, thanks for the awesome work!